### PR TITLE
Add Comment, Pagination(필수 스펙)

### DIFF
--- a/toDoMateProject/diary/models.py
+++ b/toDoMateProject/diary/models.py
@@ -8,3 +8,10 @@ class Diary(models.Model):
     date = models.DateField(unique=True)
     context = models.CharField(max_length=500, blank=False, null=False)
     created_by = models.ForeignKey(User, on_delete=models.CASCADE)
+
+
+class Comment(models.Model):
+    context = models.CharField(max_length=500, blank=False, null=False)
+    diary = models.ForeignKey(Diary, on_delete=models.CASCADE)
+    created_by = models.ForeignKey(User, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True, null=True)

--- a/toDoMateProject/diary/models.py
+++ b/toDoMateProject/diary/models.py
@@ -5,7 +5,7 @@ from accounts.models import User
 
 # Create your models here.
 class Diary(models.Model):
-    date = models.DateField(unique=True)
+    date = models.DateField()
     context = models.CharField(max_length=500, blank=False, null=False)
     created_by = models.ForeignKey(User, on_delete=models.CASCADE)
 

--- a/toDoMateProject/diary/models.py
+++ b/toDoMateProject/diary/models.py
@@ -15,3 +15,4 @@ class Comment(models.Model):
     diary = models.ForeignKey(Diary, on_delete=models.CASCADE)
     created_by = models.ForeignKey(User, on_delete=models.CASCADE)
     created_at = models.DateTimeField(auto_now_add=True, null=True)
+    updated_at = models.DateTimeField(auto_now=True, null=True)

--- a/toDoMateProject/diary/permissions.py
+++ b/toDoMateProject/diary/permissions.py
@@ -1,0 +1,13 @@
+from rest_framework import permissions
+
+
+class IsOwnerOrReadOnly(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if obj.created_by == request.user:
+            return True
+
+        if request.method in permissions.SAFE_METHODS:
+            return True
+            #팔로우 시 True로 수정
+
+        return False

--- a/toDoMateProject/diary/serializers.py
+++ b/toDoMateProject/diary/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
-from diary.models import Diary
+from diary.models import Diary, Comment
+
 
 class DiaryListSerializer(serializers.ModelSerializer):
     class Meta:
@@ -24,3 +25,23 @@ class DiaryRetrieveUpdateDeleteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Diary
         fields = ['id', 'date', 'context',  'created_by']
+
+
+class CommentListCreateSerializer(serializers.ModelSerializer):
+    diary = serializers.PrimaryKeyRelatedField(read_only=True)
+    created_at = serializers.PrimaryKeyRelatedField(read_only=True)
+    created_by = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = Comment
+        fields = ['id', 'context', 'diary', 'created_at', 'created_by']
+
+
+class CommentRetrieveUpdateDestroySerializer(serializers.ModelSerializer):
+    diary = serializers.PrimaryKeyRelatedField(read_only=True)
+    created_at = serializers.PrimaryKeyRelatedField(read_only=True)
+    created_by = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = Comment
+        fields = ['id', 'context', 'diary', 'created_at', 'created_by']

--- a/toDoMateProject/diary/serializers.py
+++ b/toDoMateProject/diary/serializers.py
@@ -9,7 +9,7 @@ class DiaryListSerializer(serializers.ModelSerializer):
         fields = ['id', 'date', 'context', 'created_by']
 
 
-class DiaryCreateSerializer(serializers.ModelSerializer):
+class DiaryListCreateSerializer(serializers.ModelSerializer):
     created_by = serializers.PrimaryKeyRelatedField(read_only=True)
     date = serializers.PrimaryKeyRelatedField(read_only=True)
 

--- a/toDoMateProject/diary/serializers.py
+++ b/toDoMateProject/diary/serializers.py
@@ -30,18 +30,20 @@ class DiaryRetrieveUpdateDeleteSerializer(serializers.ModelSerializer):
 class CommentListCreateSerializer(serializers.ModelSerializer):
     diary = serializers.PrimaryKeyRelatedField(read_only=True)
     created_at = serializers.PrimaryKeyRelatedField(read_only=True)
+    updated_at = serializers.PrimaryKeyRelatedField(read_only=True)
     created_by = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = Comment
-        fields = ['id', 'context', 'diary', 'created_at', 'created_by']
+        fields = ['id', 'context', 'diary', 'created_at', 'updated_at', 'created_by']
 
 
 class CommentRetrieveUpdateDestroySerializer(serializers.ModelSerializer):
     diary = serializers.PrimaryKeyRelatedField(read_only=True)
     created_at = serializers.PrimaryKeyRelatedField(read_only=True)
+    updated_at = serializers.PrimaryKeyRelatedField(read_only=True)
     created_by = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = Comment
-        fields = ['id', 'context', 'diary', 'created_at', 'created_by']
+        fields = ['id', 'context', 'diary', 'created_at', 'updated_at', 'created_by']

--- a/toDoMateProject/diary/urls.py
+++ b/toDoMateProject/diary/urls.py
@@ -1,10 +1,15 @@
 from django.urls import path
 
-from diary.views import DiaryListView, diary_redirect, DiaryCreateView, DiaryRetrieveUpdateDeleteView
+from diary.views import DiaryListView, diary_redirect, DiaryCreateView, DiaryRetrieveUpdateDeleteView, DiaryWatchView, \
+    CommentListCreateView, CommentRetrieveUpdateDestroyView
 
 urlpatterns = [
-    path('', DiaryListView.as_view()),
-    path('<date>', diary_redirect),
-    path('<date>/create', DiaryCreateView.as_view()),
-    path('<date>/update', DiaryRetrieveUpdateDeleteView.as_view()),
+    path('mydiary', DiaryListView.as_view()),
+    path('mydiary/<date>', diary_redirect),
+    path('mydiary/<date>/create', DiaryCreateView.as_view()),
+    path('mydiary/<date>/update', DiaryRetrieveUpdateDeleteView.as_view()),
+
+    path('watch/<did>', DiaryWatchView.as_view()),
+    path('comment/<did>', CommentListCreateView.as_view()),
+    path('comment/detail/<cid>', CommentRetrieveUpdateDestroyView.as_view()),
 ]

--- a/toDoMateProject/diary/urls.py
+++ b/toDoMateProject/diary/urls.py
@@ -1,12 +1,12 @@
 from django.urls import path
 
-from diary.views import DiaryListView, diary_redirect, DiaryCreateView, DiaryRetrieveUpdateDeleteView, DiaryWatchView, \
+from diary.views import DiaryListView, diary_redirect, DiaryListCreateView, DiaryRetrieveUpdateDeleteView, DiaryWatchView, \
     CommentListCreateView, CommentRetrieveUpdateDestroyView
 
 urlpatterns = [
     path('mydiary', DiaryListView.as_view()),
     path('mydiary/<date>', diary_redirect),
-    path('mydiary/<date>/create', DiaryCreateView.as_view()),
+    path('mydiary/<date>/create', DiaryListCreateView.as_view()),
     path('mydiary/<date>/update', DiaryRetrieveUpdateDeleteView.as_view()),
 
     path('watch/<did>', DiaryWatchView.as_view()),

--- a/toDoMateProject/diary/views.py
+++ b/toDoMateProject/diary/views.py
@@ -1,8 +1,12 @@
-from django.shortcuts import redirect
+from datetime import timezone
+
+from django.shortcuts import redirect, get_object_or_404
 from rest_framework import generics
 
-from diary.models import Diary
-from diary.serializers import DiaryListSerializer, DiaryCreateSerializer, DiaryRetrieveUpdateDeleteSerializer
+from diary.models import Diary, Comment
+from diary.permissions import IsOwnerOrReadOnly
+from diary.serializers import DiaryListSerializer, DiaryCreateSerializer, DiaryRetrieveUpdateDeleteSerializer, \
+    CommentListCreateSerializer, CommentRetrieveUpdateDestroySerializer
 
 
 # Create your views here.
@@ -12,12 +16,12 @@ class DiaryListView(generics.ListAPIView):
         return Diary.objects.filter(created_by_id=uid)
 
     serializer_class = DiaryListSerializer
-    #permission_classes = [IsAuthenticated]
+    #permission_classes = [IsOwnerOrReadOnly]
 
 
 class DiaryCreateView(generics.CreateAPIView):
     serializer_class = DiaryCreateSerializer
-    #permission_classes = [IsAuthenticated]
+    #permission_classes = [IsOwnerOrReadOnly]
 
     def perform_create(self, serializer):
         uid = self.request.user.id
@@ -33,7 +37,7 @@ class DiaryRetrieveUpdateDeleteView(generics.RetrieveUpdateDestroyAPIView):
 
     serializer_class = DiaryRetrieveUpdateDeleteSerializer
     lookup_field = 'date'
-    #permission_classes = [IsAuthenticated]
+    #permission_classes = [IsOwnerOrReadOnly]
 
 
 def diary_redirect(request, *args, **kwargs):
@@ -41,6 +45,35 @@ def diary_redirect(request, *args, **kwargs):
     diary = Diary.objects.filter(date=date).first()
 
     if diary:
-        return redirect(f"http://127.0.0.1:8000/diary/{date}/update")
+        return redirect(f"http://127.0.0.1:8000/diary/mydiary/{date}/update")
     else:
-        return redirect(f"http://127.0.0.1:8000/diary/{date}/create")
+        return redirect(f"http://127.0.0.1:8000/diary/mydiary/{date}/create")
+
+
+class DiaryWatchView(generics.RetrieveUpdateDestroyAPIView):
+    def get_object(self):
+        did = self.kwargs['did']
+        return Diary.objects.get(id=did)
+
+    serializer_class = DiaryRetrieveUpdateDeleteSerializer
+    lookup_field = 'did'
+
+
+class CommentListCreateView(generics.ListCreateAPIView):
+    def get_queryset(self):
+        did = self.kwargs['did']
+        return Comment.objects.filter(diary_id=did).order_by('created_at')
+
+    serializer_class = CommentListCreateSerializer
+
+    def perform_create(self, serializer):
+        uid = self.request.user.id
+        did = self.kwargs['did']
+        serializer.save(diary_id=did, created_by_id=uid)
+
+class CommentRetrieveUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):
+    def get_object(self):
+        cid = self.kwargs['cid']
+        return Comment.objects.get(id=cid)
+
+    serializer_class = CommentRetrieveUpdateDestroySerializer

--- a/toDoMateProject/diary/views.py
+++ b/toDoMateProject/diary/views.py
@@ -1,10 +1,8 @@
-from datetime import timezone
-
 from django.shortcuts import redirect, get_object_or_404
 from rest_framework import generics
 
 from diary.models import Diary, Comment
-from diary.permissions import IsOwnerOrReadOnly
+#from diary.permissions import IsOwnerOrReadOnly
 from diary.serializers import DiaryListSerializer, DiaryCreateSerializer, DiaryRetrieveUpdateDeleteSerializer, \
     CommentListCreateSerializer, CommentRetrieveUpdateDestroySerializer
 

--- a/toDoMateProject/diary/views.py
+++ b/toDoMateProject/diary/views.py
@@ -1,7 +1,9 @@
 from django.shortcuts import redirect, get_object_or_404
 from rest_framework import generics
+from rest_framework.permissions import IsAuthenticated
 
 from diary.models import Diary, Comment
+from diary.permissions import IsOwnerOrReadOnly
 #from diary.permissions import IsOwnerOrReadOnly
 from diary.serializers import DiaryListSerializer, DiaryCreateSerializer, DiaryRetrieveUpdateDeleteSerializer, \
     CommentListCreateSerializer, CommentRetrieveUpdateDestroySerializer
@@ -14,12 +16,12 @@ class DiaryListView(generics.ListAPIView):
         return Diary.objects.filter(created_by_id=uid)
 
     serializer_class = DiaryListSerializer
-    #permission_classes = [IsOwnerOrReadOnly]
+    permission_classes = [IsAuthenticated]
 
 
 class DiaryCreateView(generics.CreateAPIView):
     serializer_class = DiaryCreateSerializer
-    #permission_classes = [IsOwnerOrReadOnly]
+    permission_classes = [IsAuthenticated]
 
     def perform_create(self, serializer):
         uid = self.request.user.id
@@ -35,7 +37,7 @@ class DiaryRetrieveUpdateDeleteView(generics.RetrieveUpdateDestroyAPIView):
 
     serializer_class = DiaryRetrieveUpdateDeleteSerializer
     lookup_field = 'date'
-    #permission_classes = [IsOwnerOrReadOnly]
+    permission_classes = [IsAuthenticated]
 
 
 def diary_redirect(request, *args, **kwargs):
@@ -54,24 +56,32 @@ class DiaryWatchView(generics.RetrieveUpdateDestroyAPIView):
         return Diary.objects.get(id=did)
 
     serializer_class = DiaryRetrieveUpdateDeleteSerializer
+    permission_classes = [IsOwnerOrReadOnly]
     lookup_field = 'did'
 
 
 class CommentListCreateView(generics.ListCreateAPIView):
     def get_queryset(self):
         did = self.kwargs['did']
+        diary = Diary.objects.get(id=did)
+        self.check_object_permissions(self.request, diary)
         return Comment.objects.filter(diary_id=did).order_by('created_at')
 
     serializer_class = CommentListCreateSerializer
+    permission_classes = [IsOwnerOrReadOnly]
 
     def perform_create(self, serializer):
         uid = self.request.user.id
         did = self.kwargs['did']
         serializer.save(diary_id=did, created_by_id=uid)
 
+
 class CommentRetrieveUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):
     def get_object(self):
         cid = self.kwargs['cid']
-        return Comment.objects.get(id=cid)
+        comment = Comment.objects.get(id=cid)
+        self.check_object_permissions(self, self.request, comment.diary)
+        return comment
 
     serializer_class = CommentRetrieveUpdateDestroySerializer
+    permission_classes = [IsOwnerOrReadOnly]

--- a/toDoMateProject/task/models.py
+++ b/toDoMateProject/task/models.py
@@ -3,10 +3,9 @@ from accounts.models import User
 
 
 # Create your models here.
-#read_by: 0(Owner Only), 1(Followers) // 2(All Users)
-class Tag(models.Model):
-    name = models.CharField(max_length=50, blank=False, null=False)
-    created_by = models.ForeignKey(User, on_delete=models.CASCADE)
+# class Tag(models.Model):
+#     name = models.CharField(max_length=50, blank=False, null=False)
+#     created_by = models.ForeignKey(User, on_delete=models.CASCADE)
 
     #read_by = models.IntegerField(default=0)
 
@@ -19,7 +18,7 @@ class Task(models.Model):
     name = models.CharField(max_length=50, blank=False, null=False)
     complete = models.BooleanField(default=False)
     created_by = models.ForeignKey(User, on_delete=models.CASCADE)
-    tag = models.ForeignKey(Tag, on_delete=models.CASCADE, default=1)
+    #tag = models.ForeignKey(Tag, on_delete=models.CASCADE, default=1)
 
 
 # class Repeat(models.Model):

--- a/toDoMateProject/task/models.py
+++ b/toDoMateProject/task/models.py
@@ -3,21 +3,19 @@ from accounts.models import User
 
 
 # Create your models here.
+#read_by: 0(Owner Only), 1(Followers) // 2(All Users)
 class Tag(models.Model):
     name = models.CharField(max_length=50, blank=False, null=False)
     created_by = models.ForeignKey(User, on_delete=models.CASCADE)
 
-    # @classmethod
-    # def get_default_pk(cls):
-    #     exam, created = cls.objects.get_or_create(
-    #         name='common',
-    #         defaults=dict(description='this is not an exam'),
-    #     )
-    #     return exam.pk
+    #read_by = models.IntegerField(default=0)
 
 
 class Task(models.Model):
     date = models.DateField()
+    # start_date = models.DateField()
+    # end_date = models.DateField()
+    # delta_time = models.DateTimeField()
     name = models.CharField(max_length=50, blank=False, null=False)
     complete = models.BooleanField(default=False)
     created_by = models.ForeignKey(User, on_delete=models.CASCADE)

--- a/toDoMateProject/task/serializers.py
+++ b/toDoMateProject/task/serializers.py
@@ -1,12 +1,12 @@
 from rest_framework import serializers
 
-from task.models import Task, Tag
+from task.models import Task#, Tag
 
 
 class TaskListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Task
-        fields = ['id', 'date', 'name', 'complete', 'created_by', 'tag']
+        fields = ['id', 'date', 'name', 'complete', 'created_by']
 
 
 class TaskListCreateSerializer(serializers.ModelSerializer):
@@ -16,51 +16,51 @@ class TaskListCreateSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Task
-        fields = ['id', 'date', 'name', 'complete', 'created_by', 'tag']
+        fields = ['id', 'date', 'name', 'complete', 'created_by']
 
 
 class TaskDetailDestroySerializer(serializers.ModelSerializer):
     class Meta:
         model = Task
-        fields = ['id', 'date', 'name', 'complete', 'created_by', 'tag']
+        fields = ['id', 'date', 'name', 'complete', 'created_by']
 
 
 class TaskUpdateNameSerializer(serializers.ModelSerializer):
     created_by = serializers.PrimaryKeyRelatedField(read_only=True)
     complete = serializers.PrimaryKeyRelatedField(read_only=True)
     date = serializers.PrimaryKeyRelatedField(read_only=True)
-    tag = serializers.PrimaryKeyRelatedField(read_only=True)
+    #tag = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = Task
-        fields = ['id', 'date', 'name', 'complete', 'created_by', 'tag']
+        fields = ['id', 'date', 'name', 'complete', 'created_by']
 
 
 class TaskUpdateDateSerializer(serializers.ModelSerializer):
     created_by = serializers.PrimaryKeyRelatedField(read_only=True)
     complete = serializers.PrimaryKeyRelatedField(read_only=True)
     name = serializers.PrimaryKeyRelatedField(read_only=True)
-    tag = serializers.PrimaryKeyRelatedField(read_only=True)
+    #tag = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = Task
-        fields = ['id', 'date', 'name', 'complete', 'created_by', 'tag']
+        fields = ['id', 'date', 'name', 'complete', 'created_by']
+#
+#
+# class TagListCreateSerializer(serializers.ModelSerializer):
+#     created_by = serializers.PrimaryKeyRelatedField(read_only=True)
+#
+#     class Meta:
+#         model = Tag
+#         fields = ['id', 'name', 'created_by']
 
 
-class TagListCreateSerializer(serializers.ModelSerializer):
-    created_by = serializers.PrimaryKeyRelatedField(read_only=True)
-
-    class Meta:
-        model = Tag
-        fields = ['id', 'name', 'created_by']
-
-
-class TagDetailUpdateDestroySerializer(serializers.ModelSerializer):
-    created_by = serializers.PrimaryKeyRelatedField(read_only=True)
-
-    class Meta:
-        model = Tag
-        fields = ['id', 'name', 'created_by']
+# class TagDetailUpdateDestroySerializer(serializers.ModelSerializer):
+#     created_by = serializers.PrimaryKeyRelatedField(read_only=True)
+#
+#     class Meta:
+#         model = Tag
+#         fields = ['id', 'name', 'created_by']
 
 
 # class RepeatListCreateSerializer(serializers.ModelSerializer):

--- a/toDoMateProject/task/urls.py
+++ b/toDoMateProject/task/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from task.views import TaskListCreateView, TaskListView, TaskDetailDestroyView, TaskUpdateNameView, TaskUpdateDateView, \
-    switch_complete, switch_tomorrow, TagListCreateView, TagDetailUpdateDestroyView
+    switch_complete, switch_tomorrow#, TagListCreateView, TagDetailUpdateDestroyView
 
 urlpatterns = [
     path('list', TaskListView.as_view()),
@@ -14,8 +14,8 @@ urlpatterns = [
 
     #path('view/<uid>/<date>', TaskViewListView.as_view()),
 
-    path('tag', TagListCreateView.as_view()),
-    path('tag/<int:tid>', TagDetailUpdateDestroyView.as_view())
+    # path('tag', TagListCreateView.as_view()),
+    # path('tag/<int:tid>', TagDetailUpdateDestroyView.as_view())
 
     #path('list/repeated', TaskListCreateView.as_view()),
     #path('task/repeated/')

--- a/toDoMateProject/task/urls.py
+++ b/toDoMateProject/task/urls.py
@@ -12,6 +12,8 @@ urlpatterns = [
     path('detail/<int:tid>/check', switch_complete),
     path('detail/<int:tid>/delay', switch_tomorrow),
 
+    #path('view/<uid>/<date>', TaskViewListView.as_view()),
+
     path('tag', TagListCreateView.as_view()),
     path('tag/<int:tid>', TagDetailUpdateDestroyView.as_view())
 

--- a/toDoMateProject/task/views.py
+++ b/toDoMateProject/task/views.py
@@ -12,6 +12,8 @@ from task.serializers import TaskUpdateNameSerializer, TaskUpdateDateSerializer,
 # Create your views here.
 class TaskListCreateView(generics.ListCreateAPIView):
     def get_queryset(self):
+        # date = self.kwargs['date']
+        # return Task.objects.filter(date=date).order_by('tag')
         uid = self.request.user.id
         date = self.kwargs['date']
         return Task.objects.filter(created_by_id=uid, date=date).order_by('tag')
@@ -21,6 +23,8 @@ class TaskListCreateView(generics.ListCreateAPIView):
     #permission_classes = [IsAuthenticated]
 
     def perform_create(self, serializer):
+        # date = self.kwargs['date']
+        # serializer.save(date=date)
         uid = self.request.user.id
         date = self.kwargs['date']
         serializer.save(created_by_id=uid, date=date)
@@ -56,7 +60,8 @@ class TaskUpdateNameView(generics.RetrieveUpdateDestroyAPIView):
         return get_object_or_404(Task, created_by_id=uid, id=tid)
 
     serializer_class = TaskUpdateNameSerializer
-    http_method_names = ['get', 'put']
+    # permission_classes = [IsAuthenticated]
+    http_method_names = ['get', 'put', 'patch']
 
 
 class TaskUpdateDateView(generics.RetrieveUpdateDestroyAPIView):
@@ -66,7 +71,8 @@ class TaskUpdateDateView(generics.RetrieveUpdateDestroyAPIView):
         return get_object_or_404(Task, created_by_id=uid, id=tid)
 
     serializer_class = TaskUpdateDateSerializer
-    http_method_names = ['get', 'put']
+    # permission_classes = [IsAuthenticated]
+    http_method_names = ['get', 'put', 'patch']
 
 
 def switch_complete(request, *args, **kwargs):
@@ -87,12 +93,26 @@ def switch_tomorrow(request, *args, **kwargs):
     return redirect(f"http://127.0.0.1:8000/task/detail/{tid}")  # 실제 url
 
 
+# class TaskViewListView(generics.ListAPIView):
+#     def get_queryset(self):
+#         uid = self.kwargs['uid']
+#         date = self.kwargs['date']
+#         task_all = Task.objects.filter(created_by_id=uid, date=date, read_by=2)
+#         task_follow = Task.objects.filter(created_by_id=uid, date=date, read_by=1)
+#         task_owner = Task.objects.filter(created_by_id=uid, date=date, read_by=0)
+#
+#         return task_all
+#
+#     serializer_class = TaskViewListSerializer
+
+
 class TagListCreateView(generics.ListCreateAPIView):
     def get_queryset(self):
         uid = self.request.user.id
         return Tag.objects.filter(created_by_id=uid)
 
     serializer_class = TagListCreateSerializer
+    #permission_classes = [IsAuthenticated]
 
     def perform_create(self, serializer):
         uid = self.request.user.id
@@ -106,6 +126,7 @@ class TagDetailUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):
         return get_object_or_404(Tag, created_by_id=uid, id=tid)
 
     serializer_class = TagDetailUpdateDestroySerializer
+    #permission_classes = [IsAuthenticated]
 
 
 # class RepeatListCreateView(generics.ListCreateAPIView):

--- a/toDoMateProject/task/views.py
+++ b/toDoMateProject/task/views.py
@@ -4,10 +4,9 @@ from django.shortcuts import render, get_object_or_404, redirect
 from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
 
-from task.models import Task, Tag
+from task.models import Task#, Tag
 from task.serializers import TaskUpdateNameSerializer, TaskUpdateDateSerializer, \
-    TagListCreateSerializer, TaskDetailDestroySerializer, TaskListCreateSerializer, TaskListSerializer, \
-    TagDetailUpdateDestroySerializer
+    TaskDetailDestroySerializer, TaskListCreateSerializer, TaskListSerializer
 
 
 # Create your views here.
@@ -17,7 +16,7 @@ class TaskListCreateView(generics.ListCreateAPIView):
         # return Task.objects.filter(date=date).order_by('tag')
         uid = self.request.user.id
         date = self.kwargs['date']
-        return Task.objects.filter(created_by_id=uid, date=date).order_by('tag')
+        return Task.objects.filter(created_by_id=uid, date=date)
         #return Task.objects.filter(created_by_id=uid, repeated=0) | Task.objects.filter(created_by_id=uid, repeated=1)
 
     serializer_class = TaskListCreateSerializer
@@ -35,7 +34,7 @@ class TaskListCreateView(generics.ListCreateAPIView):
 class TaskListView(generics.ListAPIView):
     def get_queryset(self):
         uid = self.request.user.id
-        return Task.objects.filter(created_by_id=uid).order_by('date', 'tag')
+        return Task.objects.filter(created_by_id=uid).order_by('date')
         #return Task.objects.filter(created_by_id=uid, date=date, repeated=0) | Task.objects.filter(created_by_id=uid, date=date, repeated=1)
 
     serializer_class = TaskListSerializer
@@ -107,27 +106,27 @@ def switch_tomorrow(request, *args, **kwargs):
 #     serializer_class = TaskViewListSerializer
 
 
-class TagListCreateView(generics.ListCreateAPIView):
-    def get_queryset(self):
-        uid = self.request.user.id
-        return Tag.objects.filter(created_by_id=uid)
-
-    serializer_class = TagListCreateSerializer
-    permission_classes = [IsAuthenticated]
-
-    def perform_create(self, serializer):
-        uid = self.request.user.id
-        serializer.save(created_by_id=uid)
-
-
-class TagDetailUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):
-    def get_object(self):
-        uid = self.request.user.id
-        tid = self.kwargs['tid']
-        return get_object_or_404(Tag, created_by_id=uid, id=tid)
-
-    serializer_class = TagDetailUpdateDestroySerializer
-    permission_classes = [IsAuthenticated]
+# class TagListCreateView(generics.ListCreateAPIView):
+#     def get_queryset(self):
+#         uid = self.request.user.id
+#         return Tag.objects.filter(created_by_id=uid)
+#
+#     serializer_class = TagListCreateSerializer
+#     permission_classes = [IsAuthenticated]
+#
+#     def perform_create(self, serializer):
+#         uid = self.request.user.id
+#         serializer.save(created_by_id=uid)
+#
+#
+# class TagDetailUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):
+#     def get_object(self):
+#         uid = self.request.user.id
+#         tid = self.kwargs['tid']
+#         return get_object_or_404(Tag, created_by_id=uid, id=tid)
+#
+#     serializer_class = TagDetailUpdateDestroySerializer
+#     permission_classes = [IsAuthenticated]
 
 
 # class RepeatListCreateView(generics.ListCreateAPIView):

--- a/toDoMateProject/task/views.py
+++ b/toDoMateProject/task/views.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.shortcuts import render, get_object_or_404, redirect
 from rest_framework import generics
+from rest_framework.permissions import IsAuthenticated
 
 from task.models import Task, Tag
 from task.serializers import TaskUpdateNameSerializer, TaskUpdateDateSerializer, \
@@ -20,7 +21,7 @@ class TaskListCreateView(generics.ListCreateAPIView):
         #return Task.objects.filter(created_by_id=uid, repeated=0) | Task.objects.filter(created_by_id=uid, repeated=1)
 
     serializer_class = TaskListCreateSerializer
-    #permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated]
 
     def perform_create(self, serializer):
         # date = self.kwargs['date']
@@ -38,7 +39,7 @@ class TaskListView(generics.ListAPIView):
         #return Task.objects.filter(created_by_id=uid, date=date, repeated=0) | Task.objects.filter(created_by_id=uid, date=date, repeated=1)
 
     serializer_class = TaskListSerializer
-    #permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated]
 
 
 class TaskDetailDestroyView(generics.RetrieveUpdateDestroyAPIView):
@@ -49,7 +50,7 @@ class TaskDetailDestroyView(generics.RetrieveUpdateDestroyAPIView):
         #return get_object_or_404(Task, created_by_id=uid, id=tid, repeated=0)
 
     serializer_class = TaskDetailDestroySerializer
-    #permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated]
     http_method_names = ['get', 'delete']
 
 
@@ -60,7 +61,7 @@ class TaskUpdateNameView(generics.RetrieveUpdateDestroyAPIView):
         return get_object_or_404(Task, created_by_id=uid, id=tid)
 
     serializer_class = TaskUpdateNameSerializer
-    # permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated]
     http_method_names = ['get', 'put', 'patch']
 
 
@@ -71,7 +72,7 @@ class TaskUpdateDateView(generics.RetrieveUpdateDestroyAPIView):
         return get_object_or_404(Task, created_by_id=uid, id=tid)
 
     serializer_class = TaskUpdateDateSerializer
-    # permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated]
     http_method_names = ['get', 'put', 'patch']
 
 
@@ -112,7 +113,7 @@ class TagListCreateView(generics.ListCreateAPIView):
         return Tag.objects.filter(created_by_id=uid)
 
     serializer_class = TagListCreateSerializer
-    #permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated]
 
     def perform_create(self, serializer):
         uid = self.request.user.id
@@ -126,7 +127,7 @@ class TagDetailUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):
         return get_object_or_404(Tag, created_by_id=uid, id=tid)
 
     serializer_class = TagDetailUpdateDestroySerializer
-    #permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated]
 
 
 # class RepeatListCreateView(generics.ListCreateAPIView):

--- a/toDoMateProject/toDoMateProject/settings.py
+++ b/toDoMateProject/toDoMateProject/settings.py
@@ -83,7 +83,9 @@ SOCIALACCOUNT_AUTO_SIGNUP = True
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
-    )
+    ),
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 2
 }
 
 REST_AUTH_SERIALIZERS = {
@@ -215,14 +217,9 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.1/howto/static-files/
-
 STATIC_URL = 'static/'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
-
-SESSION_COOKIE_SECURE = True
-CSRF_COOKIE_SECURE = True
-SECURE_SSL_REDIRECT = True


### PR DESCRIPTION
기본적인 댓글 추가, 조회, 수정, 삭제
pagination

코멘트 편집 시각(updated_at) 추가했습니다

permissions 추가했습니다(follower 자체는 구현 X):
1. diary/watch/<did>, diary/comment/<did>, diary/comment/detail/<cid>로 볼 시 diary creater는 모든 method 가능, follower는 SAFE_METHODS만 가능
2. 이를 제외한 모든 URL은 IsAuthenticated만 필요, 해당 시 자동으로 본인의 데이터를 보여줌

* 현재 accounts 구현에 대해서도 IsAuthenticated가 적용 가능한가요?
* 댓글과 팔로우 permissions은 모두 일기 기능에만 구현되어 있습니다. 일정 기능은 현재 본인의 일정만 조회할 수 있도록 설정되어 있습니다